### PR TITLE
Fix Resolve paths for Linux

### DIFF
--- a/storytoolkitai/integrations/mots_resolve.py
+++ b/storytoolkitai/integrations/mots_resolve.py
@@ -195,8 +195,8 @@ class MotsResolve:
                 elif platform.system() == 'Linux':
                     default_resolve_dir = '/opt/resolve/'
 
-                    # @todo find out the executable name for Davinci Resolve on Linux
-                    executable = '/bin/resolve'
+                    # Confirmed working on Fedora 40 with KDE Plasma 6 (Wayland)
+                    executable = 'bin/resolve'
 
                 else:
                     # check if the default path has it...
@@ -231,7 +231,8 @@ class MotsResolve:
                     expectedPath = os.getenv(
                         'PROGRAMDATA') + "\\Blackmagic Design\\DaVinci Resolve\\Support\\Developer\\Scripting\\Modules\\"
                 elif sys.platform.startswith("linux"):
-                    expectedPath = "/opt/resolve/libs/Fusion/Modules/"
+                    # Confirmed working on Fedora 40 with KDE lasma 6 (Wayland).
+                    expectedPath = "/opt/resolve/Developer/Scripting/Modules/"
 
                 # check if the default path has it...
                 self.logger.debug("Unable to find module DaVinciResolveScript from PYTHONPATH "


### PR DESCRIPTION
**Issue:**
The program does not find the installation of Resolve or the file `DaVinciResolveScript.py`

**Intended behaviour:**
On a system with Resolve Studio installed, the program should recognise that Resolve is indeed installed.

**Actual behaviour:**
Throws the following error:
`ERROR: DaVinci Resolve not installed at the default location: /opt/resolve/`
`WARNING: Resolve API connection disabled`
The API connection stays disabled and cannot be enabled.

**Affects:**
Linux-based installations (tested on Fedora 40 using KDE Plasma 6 on Wayland).

**Changes:**
- Removed a leading slash for the executable to fix path joining
- Corrected expected path of DaVinciResolveScript.py

While I am aware that StoryToolkitAI does not officially support Linux, I got it working with these tiny changes. The software is slightly buggy (transcription editing sometimes causes the cursor to jump around the text), but at least transcription using CPU and the Whisper medium model works pretty flawlessly. The synced playhead through the Resolve connection also works well.