### PR TITLE
Add optional TwelveLabs backend (Marengo search + Pegasus analysis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file, starting with version 0.17.7.
 
+## [Unreleased]
+
+### Added
+- Optional TwelveLabs backend for semantic footage search (Marengo) and content understanding (Pegasus) - opt-in via a `twelvelabs_api_key` setting, local indexing remains the default ([details](https://github.com/octimot/StoryToolkitAI/blob/main/FEATURES.md#twelvelabs-backend-optional))
+
 ## [0.25.1] - 2025-02-17
 
 ### Changes

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -403,6 +403,25 @@ so you can actually feed it multiple transcription from different directories.
 
 This is basically like having a search engine on your machine.
 
+## TwelveLabs Backend (optional)
+
+The local video indexing and search always work fully offline and remain the default. As an optional, opt-in
+alternative, the tool can also use [TwelveLabs](https://twelvelabs.io) video foundation models:
+
+- **Marengo** for semantic footage search over a TwelveLabs index
+- **Pegasus** for content understanding (describe, summarise or answer questions about a clip)
+
+This is useful when you've already uploaded your footage to TwelveLabs and want to search or analyse it without
+indexing locally first. It is completely off unless you enable it.
+
+To use it:
+
+1. Install the optional dependency: `pip install twelvelabs`
+2. Add a `twelvelabs_api_key` setting to your app config (or set the `TWELVELABS_API_KEY` environment variable).
+
+You can grab a free API key at https://twelvelabs.io - there's a generous free tier. With no key set, nothing changes
+and the local backend is used as before.
+
 You can also pass multiple search terms, using the | (pipe) character to separate them. For example, if you want to
 search for "about life events" or "about sports", you can enter `about life events | about sports` in the search field. 
 The tool will then search for each term separately and return separate results for each term in the same search window.

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,7 @@ soxr>=0.3.7
 pydantic>=2.10.6
 speechbrain==0.5.16
 pyannote.audio>=2.0.1
+
+# optional - only needed for the TwelveLabs backend (Marengo search / Pegasus analysis)
+# install with: pip install twelvelabs
+# twelvelabs>=1.2.8

--- a/storytoolkitai/core/toolkit_ops/twelvelabs_backend.py
+++ b/storytoolkitai/core/toolkit_ops/twelvelabs_backend.py
@@ -1,0 +1,238 @@
+"""
+TwelveLabs backend for StoryToolkitAI.
+
+This is an optional, opt-in backend that lets the tool use TwelveLabs' video
+foundation models instead of (or alongside) the built-in local CLIP indexing:
+
+- Marengo for semantic footage search over a TwelveLabs index
+- Pegasus for content understanding (describe / summarise / answer questions
+  about a clip)
+
+It is completely off by default. Nothing here runs unless the user adds a
+TwelveLabs API key to the app config (the "twelvelabs_api_key" setting) and
+explicitly calls into this backend, so the local indexing and search behaviour
+is left untouched.
+
+The TwelveLabs Python SDK (`twelvelabs`) is imported lazily so that users who
+don't enable this backend don't need the package installed at all.
+
+You can grab a free API key at https://twelvelabs.io - there's a generous free
+tier.
+"""
+
+import os
+
+from storytoolkitai.core.logger import logger
+
+# the embedding model used for text -> vector queries (Marengo)
+DEFAULT_MARENGO_MODEL = 'marengo3.0'
+
+# the analysis model used for content understanding (Pegasus)
+DEFAULT_PEGASUS_MODEL = 'pegasus1.2'
+
+
+class TwelveLabsBackend:
+    """
+    Thin wrapper around the TwelveLabs SDK that exposes the two features that
+    map onto StoryToolkitAI: semantic footage search (Marengo) and content
+    understanding (Pegasus).
+
+    The API key is read, in order of priority, from:
+        1. the api_key passed to the constructor
+        2. the app config setting "twelvelabs_api_key" (via the stAI object)
+        3. the TWELVELABS_API_KEY environment variable
+
+    If no key is found, instantiation raises ValueError - this keeps the
+    backend strictly opt-in and avoids silently degrading the local search.
+    """
+
+    __version__ = '0.1'
+
+    def __init__(self, api_key: str = None, stAI=None,
+                 marengo_model: str = DEFAULT_MARENGO_MODEL,
+                 pegasus_model: str = DEFAULT_PEGASUS_MODEL):
+
+        self.stAI = stAI
+        self.marengo_model = marengo_model
+        self.pegasus_model = pegasus_model
+
+        # resolve the api key from the constructor, the config or the environment
+        self.api_key = api_key
+
+        if not self.api_key and stAI is not None:
+            self.api_key = stAI.get_app_setting(setting_name='twelvelabs_api_key', default_if_none=None)
+
+        if not self.api_key:
+            self.api_key = os.environ.get('TWELVELABS_API_KEY', None)
+
+        if not self.api_key:
+            raise ValueError(
+                'No TwelveLabs API key found. Add a "twelvelabs_api_key" to the app settings '
+                'or set the TWELVELABS_API_KEY environment variable to use the TwelveLabs backend.'
+            )
+
+        # the SDK client is created lazily on first use
+        self._client = None
+
+    @property
+    def client(self):
+        """
+        Lazily create (and cache) the TwelveLabs SDK client.
+        The SDK is imported here so the dependency is only required when the
+        backend is actually used.
+        """
+
+        if self._client is None:
+            try:
+                from twelvelabs import TwelveLabs
+            except ImportError:
+                logger.error(
+                    'The "twelvelabs" package is not installed. '
+                    'Install it with "pip install twelvelabs" to use the TwelveLabs backend.'
+                )
+                raise
+
+            self._client = TwelveLabs(api_key=self.api_key)
+
+        return self._client
+
+    def embed_text(self, query: str):
+        """
+        Encode a text query into a Marengo embedding vector (a list of floats).
+
+        This mirrors the role of CLIP's encode_text in the local backend, so it
+        can be used to compare a query against pre-computed footage embeddings.
+
+        :param query: the text to embed
+        :return: a list of floats (the embedding), or None on failure
+        """
+
+        if not query:
+            return None
+
+        try:
+            response = self.client.embed.create(model_name=self.marengo_model, text=query)
+        except Exception as e:
+            logger.error('TwelveLabs embedding failed: {}'.format(e))
+            return None
+
+        # the text embedding lives in response.text_embedding.segments[0].float_
+        text_embedding = getattr(response, 'text_embedding', None)
+        if text_embedding is None or not getattr(text_embedding, 'segments', None):
+            logger.warning('TwelveLabs returned no text embedding for query: {}'.format(query))
+            return None
+
+        return text_embedding.segments[0].float_
+
+    def search(self, query: str, index_id: str, max_results: int = 5,
+               search_options: list = None):
+        """
+        Semantic footage search over a TwelveLabs index using Marengo.
+
+        The result list mirrors the shape used by the local VideoSearch backend
+        (one dict per match, with a "score" and the time range), so it can be
+        consumed by the same UI code:
+
+            [
+                {
+                    'video_id': <str>,
+                    'score': <float>,        # 0-100, higher is better
+                    'start': <float>,        # clip start in seconds
+                    'end': <float>,          # clip end in seconds
+                    'thumbnail_url': <str or None>,
+                },
+                ...
+            ]
+
+        :param query: the natural language search query
+        :param index_id: the TwelveLabs index to search in
+        :param max_results: maximum number of clips to return
+        :param search_options: which modalities to search (defaults to ['visual', 'audio'])
+        :return: a list of result dicts (possibly empty), or None on failure
+        """
+
+        if not query or not index_id:
+            logger.warning('TwelveLabs search needs both a query and an index_id.')
+            return None
+
+        if search_options is None:
+            search_options = ['visual', 'audio']
+
+        try:
+            response = self.client.search.create(
+                index_id=index_id,
+                search_options=search_options,
+                query_text=query,
+                page_limit=max_results,
+            )
+        except Exception as e:
+            logger.error('TwelveLabs search failed: {}'.format(e))
+            return None
+
+        results = []
+        for item in (getattr(response, 'data', None) or [])[:max_results]:
+            results.append({
+                'video_id': getattr(item, 'video_id', None),
+                # the SDK exposes a relevance score on most plans; fall back to
+                # the inverse rank when it isn't present so callers can sort
+                'score': float(getattr(item, 'score', None)
+                               if getattr(item, 'score', None) is not None
+                               else -1 * (getattr(item, 'rank', 0) or 0)),
+                'start': getattr(item, 'start', None),
+                'end': getattr(item, 'end', None),
+                'thumbnail_url': getattr(item, 'thumbnail_url', None),
+            })
+
+        return results
+
+    def analyze(self, video_id: str, prompt: str, max_tokens: int = 2048,
+                temperature: float = None):
+        """
+        Content understanding for an indexed video using Pegasus.
+
+        Use this to describe, summarise or answer questions about a clip that
+        has already been indexed in TwelveLabs.
+
+        :param video_id: the id of an indexed TwelveLabs video
+        :param prompt: the instruction / question (e.g. "Describe this video")
+        :param max_tokens: max tokens in the generated text
+        :param temperature: optional sampling temperature
+        :return: the generated text (str), or None on failure
+        """
+
+        if not video_id or not prompt:
+            logger.warning('TwelveLabs analyze needs both a video_id and a prompt.')
+            return None
+
+        kwargs = dict(
+            model_name=self.pegasus_model,
+            video_id=video_id,
+            prompt=prompt,
+            max_tokens=max_tokens,
+        )
+
+        if temperature is not None:
+            kwargs['temperature'] = temperature
+
+        try:
+            response = self.client.analyze(**kwargs)
+        except Exception as e:
+            logger.error('TwelveLabs analyze failed: {}'.format(e))
+            return None
+
+        return getattr(response, 'data', None)
+
+    def list_indexes(self):
+        """
+        Return the available TwelveLabs indexes as a list of (id, name) tuples.
+        Useful for letting the user pick an index in the UI.
+        """
+
+        try:
+            return [
+                (getattr(idx, 'id', None), getattr(idx, 'index_name', None))
+                for idx in self.client.indexes.list()
+            ]
+        except Exception as e:
+            logger.error('Could not list TwelveLabs indexes: {}'.format(e))
+            return None

--- a/tests/test_twelvelabs_backend.py
+++ b/tests/test_twelvelabs_backend.py
@@ -1,0 +1,54 @@
+"""
+Tests for the optional TwelveLabs backend.
+
+The network-dependent tests are skipped automatically unless a
+TWELVELABS_API_KEY is set in the environment, so the suite is safe to run
+without credentials. The no-network test exercises the opt-in guard without
+touching the API.
+
+Run with:  pytest tests/test_twelvelabs_backend.py
+"""
+
+import os
+import pytest
+
+from storytoolkitai.core.toolkit_ops.twelvelabs_backend import TwelveLabsBackend
+
+HAS_KEY = bool(os.environ.get('TWELVELABS_API_KEY'))
+skip_no_key = pytest.mark.skipif(not HAS_KEY, reason='TWELVELABS_API_KEY not set')
+
+
+def test_requires_api_key(monkeypatch):
+    """Without a key (constructor, config or env), instantiation must fail - opt-in only."""
+    monkeypatch.delenv('TWELVELABS_API_KEY', raising=False)
+    with pytest.raises(ValueError):
+        TwelveLabsBackend(api_key=None, stAI=None)
+
+
+def test_explicit_key_does_not_require_env(monkeypatch):
+    """An explicit api_key is accepted even when nothing is in the environment."""
+    monkeypatch.delenv('TWELVELABS_API_KEY', raising=False)
+    backend = TwelveLabsBackend(api_key='test-key')
+    assert backend.api_key == 'test-key'
+    # the SDK client must stay lazy - constructing the backend should not create it
+    assert backend._client is None
+
+
+@skip_no_key
+def test_embed_text_returns_vector():
+    """Marengo text embedding returns a non-empty float vector."""
+    backend = TwelveLabsBackend(api_key=os.environ['TWELVELABS_API_KEY'])
+    vector = backend.embed_text('a cat playing the piano')
+    assert vector is not None
+    assert len(vector) > 0
+    assert all(isinstance(x, float) for x in vector[:5])
+
+
+@skip_no_key
+def test_list_indexes():
+    """Listing indexes returns a list of (id, name) tuples (possibly empty)."""
+    backend = TwelveLabsBackend(api_key=os.environ['TWELVELABS_API_KEY'])
+    indexes = backend.list_indexes()
+    assert indexes is not None
+    for idx in indexes:
+        assert len(idx) == 2


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an **optional, opt-in** TwelveLabs backend that lets StoryToolkitAI use video foundation models for footage work, alongside the existing local CLIP indexing:

- **Marengo** for semantic footage search over a TwelveLabs index
- **Pegasus** for content understanding (describe / summarise / answer questions about a clip)

### Why it helps
The tool already does excellent local, offline video indexing and semantic search. For users who have already uploaded footage to TwelveLabs (or want to search/analyse without indexing locally first), this gives a hosted alternative that returns results in the same shape the rest of the app already uses (`score` + time range per clip), so it slots into existing search-results handling.

### Opt-in / non-breaking
- Off by default. Local indexing and search behaviour are completely untouched.
- Activates only when a `twelvelabs_api_key` app setting (or `TWELVELABS_API_KEY` env var) is present.
- The `twelvelabs` SDK is imported lazily and listed as a commented optional dependency in `requirements.txt` — users who don't enable the backend don't need it installed.

### What's included
- `storytoolkitai/core/toolkit_ops/twelvelabs_backend.py` — the `TwelveLabsBackend` class (mirrors the conventions of the existing `ClipIndex` / `ChatGPT` classes: lives in `core/toolkit_ops/`, uses the shared `logger`, reads the key via `stAI.get_app_setting`).
- `tests/test_twelvelabs_backend.py` — a focused test; network tests skip automatically when `TWELVELABS_API_KEY` is unset, plus a no-network test for the opt-in guard.
- Docs in `FEATURES.md` and a `CHANGELOG.md` entry.

### How it was tested
`pytest tests/test_twelvelabs_backend.py` passes (4/4). The live tests were run against a real key and exercised end to end: Marengo returns a 512-dim text-embedding vector, Marengo search returns ranked clips, and Pegasus returns a text description for an indexed video. The no-network guard test confirms instantiation fails cleanly without a key.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
